### PR TITLE
Fix issue where propel reverse breaks with system-versioned tables

### DIFF
--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -431,7 +431,9 @@ class MysqlSchemaParser extends AbstractSchemaParser
                 continue;
             }
             $name = $row['Column_name'];
-            $table->getColumn($name)->setPrimaryKey(true);
+            if ($column = $table->getColumn($name)) {
+                $column->setPrimaryKey(true);
+            }
         }
     }
 


### PR DESCRIPTION
MariaDB 10.3.4 introduced system-versioned tables (https://mariadb.com/kb/en/temporal-data-tables/).

There is a known issue (possibly a bug) that can cause issues for ORM tools like Propel, described here: https://jira.mariadb.org/browse/MDEV-16857?focusedCommentId=117570&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-117570

"ORM tool will be confused as the primary key definition in the database doesn't match the one defined in application code after system versioning is enabled."

Basically, system versioning creates an invisible primary key that shows up with "SHOW KEYS FROM table" but not with "SHOW COLUMNS FROM table". This PR fixes that by skipping these invisible primary key columns when generating the schema.